### PR TITLE
remove extraneous comment close tag

### DIFF
--- a/page.php
+++ b/page.php
@@ -31,7 +31,7 @@ get_header(); ?>
 			?>
 
 		</main><!-- #main -->
-	<!-- </div><!-- #primary --> -->
+	<!-- </div><!-- #primary -->
 
 <?php
 get_sidebar();


### PR DESCRIPTION
This extra comment close tag was showing up on the mobile version of pages. This should fix that!