### PR TITLE
Register a new widget in the header, add new widget to the header

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -208,6 +208,15 @@ function kuhn_widgets_init() {
 		'before_title'  => '<h2 class="widget-title">',
 		'after_title'   => '</h2>',
 	) );
+	register_sidebar( array(
+ 		'name'          => esc_html__( 'Header', 'kuhn' ),
+		'id'            => 'header-1',
+		'description'   => esc_html__( 'Add headerwidgets here.', 'kuhn' ),
+		'before_widget' => '<div id="%1$s" class="site-branding widget %2$s">',
+		'after_widget'  => '</div>',
+		'before_title'  => '<h2 class="widget-title">',
+		'after_title'   => '</h2>',   	
+	) );
 }
 add_action( 'widgets_init', 'kuhn_widgets_init' );
 

--- a/header.php
+++ b/header.php
@@ -46,5 +46,11 @@
 			<button class="menu-toggle" aria-controls="primary-menu" aria-expanded="false"><?php esc_html_e( 'Primary Menu', 'kuhn' ); ?></button>
 			<?php wp_nav_menu( array( 'theme_location' => 'primary', 'menu_id' => 'primary-menu' ) ); ?>
 		</nav><!-- #site-navigation -->
+
+		<?php
+        	if ( is_active_sidebar( 'header-1' ) ) {
+        	    dynamic_sidebar( 'header-1' );
+        	}
+        	?>
 	</header><!-- #masthead -->
 


### PR DESCRIPTION
I thought I'd pass along I change I needed for myself. This PR registers a new widget ID'd _header-1_ and adds it to the end of the header/masthead. Could be useful for adding additional menus, additional text blocks, a search box, tag box, etc.